### PR TITLE
bug fixed

### DIFF
--- a/read.go
+++ b/read.go
@@ -174,14 +174,16 @@ func (c *ConfigFile) read(reader io.Reader) (err error) {
 				key = "#" + fmt.Sprint(count)
 				count++
 			}
-			vi := i + 1
-			firstChar := ""
-			if lineLengh >= vi+2 {
-				firstChar = line[vi : vi+1]
-			}
+
 			//[SWH|+]:支持引号包围起来的字串
+			lineRight := strings.TrimSpace(line[i+1:])
+			lineRightLength := len(lineRight)
+			firstChar := ""
+			if lineRightLength >= 2 {
+				firstChar = lineRight[0:1]
+			}
 			if firstChar == `"` {
-				if lineLengh >= vi+6 && line[vi:vi+3] == `"""` {
+				if lineRightLength >= 6 && lineRight[0:3] == `"""` {
 					valQuote = `"""`
 				} else {
 					valQuote = `"`
@@ -190,15 +192,15 @@ func (c *ConfigFile) read(reader io.Reader) (err error) {
 				valQuote = "`"
 			}
 			if valQuote != "" {
-				qLen := vi + len(valQuote)
-				pos := strings.LastIndex(line[qLen:], valQuote)
+				qLen := len(valQuote)
+				pos := strings.LastIndex(lineRight[qLen:], valQuote)
 				if pos == -1 {
 					return readError{CouldNotParse, line}
 				}
 				pos = pos + qLen
-				value = strings.TrimSpace(line[qLen:pos])
+				value = lineRight[qLen:pos]
 			} else {
-				value = strings.TrimSpace(line[vi:])
+				value = strings.TrimSpace(lineRight[0:])
 			}
 			//[SWH|+];
 

--- a/testdata/conf2.ini
+++ b/testdata/conf2.ini
@@ -9,7 +9,7 @@ search=http://%(google)s
 key1=Let's us goconfig!!!
 key2=rewrite this key of conf.ini
 key3=this is based on key2:%(key2)s
-"key:1"=`This is the value of "key:1"`
+"key:1" = `This is the value of "key:1"`
 """key:2"""="""this is based on "key:1" => `%(key:1)s`"""
 
 [What's this?]


### PR DESCRIPTION
修正赋值符号“=”或“:”两端带空格时解析失败的bug

Signed-off-by: 商讯在线 swhbox@foxmail.com
