### PR TITLE
Add pure in-memory operations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,15 @@ Please see [conf.ini](testdata/conf.ini) as an example.
 - Finally, `SaveConfigFile` saves your configuration to local file system.
 - Use method `Reload` in case someone else modified your file(s).
 - Methods contains `Comment` help you manipulate comments.
+- `LoadFromReader` allows loading data without an intermediate file.
+- `SaveConfigData` added, which writes configuration to an arbitrary writer.
+- `ReloadData` allows to reload data from memory.
+
+Note that you cannot mix in-memory configuration with on-disk configuration.
 
 ## More Information
 
-- All characters are CASE SENSITIVE, BE CAREFULL!
+- All characters are CASE SENSITIVE, BE CAREFUL!
 
 ## Credits
 

--- a/goconfig_test.go
+++ b/goconfig_test.go
@@ -15,7 +15,9 @@
 package goconfig
 
 import (
+	"bytes"
 	"fmt"
+	"io/ioutil"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
@@ -204,6 +206,19 @@ func TestSaveConfigFile(t *testing.T) {
 	})
 }
 
+func TestSaveConfigData(t *testing.T) {
+	Convey("Save a ConfigFile to file system", t, func() {
+		c, err := LoadConfigFile("testdata/conf.ini", "testdata/conf2.ini")
+		So(err, ShouldBeNil)
+		So(c, ShouldNotBeNil)
+
+		c.SetValue("", "", "empty")
+		var dst bytes.Buffer
+		So(SaveConfigData(c, &dst), ShouldBeNil)
+		So(dst.Len(), ShouldNotEqual, 0)
+	})
+}
+
 func TestReload(t *testing.T) {
 	Convey("Reload a configuration file", t, func() {
 		c, err := LoadConfigFile("testdata/conf.ini", "testdata/conf2.ini")
@@ -211,6 +226,18 @@ func TestReload(t *testing.T) {
 		So(c, ShouldNotBeNil)
 
 		So(c.Reload(), ShouldBeNil)
+	})
+}
+
+func TestReloadData(t *testing.T) {
+	Convey("Reload a configuration file", t, func() {
+		data, err := ioutil.ReadFile("testdata/conf.ini")
+		So(err, ShouldBeNil)
+		c, err := LoadFromReader(bytes.NewBuffer(data))
+		So(err, ShouldBeNil)
+		So(c, ShouldNotBeNil)
+
+		So(c.ReloadData(bytes.NewBuffer(data)), ShouldBeNil)
 	})
 }
 
@@ -342,6 +369,14 @@ func TestArray(t *testing.T) {
 func TestLoadFromData(t *testing.T) {
 	Convey("Load config file from data", t, func() {
 		c, err := LoadFromData([]byte(""))
+		So(err, ShouldBeNil)
+		So(c, ShouldNotBeNil)
+	})
+}
+
+func TestLoadFromReader(t *testing.T) {
+	Convey("Load config file from reader", t, func() {
+		c, err := LoadFromReader(bytes.NewBuffer([]byte("")))
 		So(err, ShouldBeNil)
 		So(c, ShouldNotBeNil)
 	})

--- a/read.go
+++ b/read.go
@@ -176,16 +176,31 @@ func (c *ConfigFile) read(reader io.Reader) (err error) {
 
 // LoadFromData accepts raw data directly from memory
 // and returns a new configuration representation.
+// Note that the configuration is written to the system
+// temporary folder, so your file should not contain
+// sensitive information.
 func LoadFromData(data []byte) (c *ConfigFile, err error) {
 	// Save memory data to temporary file to support further operations.
 	tmpName := path.Join(os.TempDir(), "goconfig", fmt.Sprintf("%d", time.Now().Nanosecond()))
-	os.MkdirAll(path.Dir(tmpName), os.ModePerm)
+	if err = os.MkdirAll(path.Dir(tmpName), os.ModePerm); err != nil {
+		return nil, err
+	}
 	if err = ioutil.WriteFile(tmpName, data, 0655); err != nil {
 		return nil, err
 	}
 
 	c = newConfigFile([]string{tmpName})
 	err = c.read(bytes.NewBuffer(data))
+	return c, err
+}
+
+// LoadFromReader accepts raw data directly from a reader
+// and returns a new configuration representation.
+// You must use ReloadData to reload.
+// You cannot append files a configfile read this way.
+func LoadFromReader(in io.Reader) (c *ConfigFile, err error) {
+	c = newConfigFile([]string{""})
+	err = c.read(in)
 	return c, err
 }
 
@@ -224,6 +239,9 @@ func LoadConfigFile(fileName string, moreFiles ...string) (c *ConfigFile, err er
 func (c *ConfigFile) Reload() (err error) {
 	var cfg *ConfigFile
 	if len(c.fileNames) == 1 {
+		if c.fileNames[0] == "" {
+			return fmt.Errorf("file opened from in-memory data, use ReloadData to reload")
+		}
 		cfg, err = LoadConfigFile(c.fileNames[0])
 	} else {
 		cfg, err = LoadConfigFile(c.fileNames[0], c.fileNames[1:]...)
@@ -235,8 +253,25 @@ func (c *ConfigFile) Reload() (err error) {
 	return err
 }
 
+// ReloadData reloads configuration file from memory
+func (c *ConfigFile) ReloadData(in io.Reader) (err error) {
+	var cfg *ConfigFile
+	if len(c.fileNames) != 1 {
+		return fmt.Errorf("Multiple files loaded, unable to mix in-memory and file data")
+	}
+
+	cfg, err = LoadFromReader(in)
+	if err == nil {
+		*c = *cfg
+	}
+	return err
+}
+
 // AppendFiles appends more files to ConfigFile and reload automatically.
 func (c *ConfigFile) AppendFiles(files ...string) error {
+	if len(c.fileNames) == 1 && c.fileNames[0] == "" {
+		return fmt.Errorf("Cannot append file data to in-memory data")
+	}
 	c.fileNames = append(c.fileNames, files...)
 	return c.Reload()
 }

--- a/write.go
+++ b/write.go
@@ -16,6 +16,7 @@ package goconfig
 
 import (
 	"bytes"
+	"io"
 	"os"
 	"strings"
 )
@@ -23,14 +24,8 @@ import (
 // Write spaces around "=" to look better.
 var PrettyFormat = true
 
-// SaveConfigFile writes configuration file to local file system
-func SaveConfigFile(c *ConfigFile, filename string) (err error) {
-	// Write configuration file by filename.
-	var f *os.File
-	if f, err = os.Create(filename); err != nil {
-		return err
-	}
-
+// SaveConfigData writes configuration to a writer
+func SaveConfigData(c *ConfigFile, out io.Writer) (err error) {
 	equalSign := "="
 	if PrettyFormat {
 		equalSign = " = "
@@ -101,7 +96,21 @@ func SaveConfigFile(c *ConfigFile, filename string) (err error) {
 		}
 	}
 
-	if _, err = buf.WriteTo(f); err != nil {
+	if _, err := buf.WriteTo(out); err != nil {
+		return err
+	}
+	return nil
+}
+
+// SaveConfigFile writes configuration file to local file system
+func SaveConfigFile(c *ConfigFile, filename string) (err error) {
+	// Write configuration file by filename.
+	var f *os.File
+	if f, err = os.Create(filename); err != nil {
+		return err
+	}
+
+	if err := SaveConfigData(c, f); err != nil {
 		return err
 	}
 	return f.Close()


### PR DESCRIPTION
This allows for pure in-memory operation using the `io.Reader` and `io.Writer` interfaces.

It should remain compatible for all existing users.