### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/conf.go
+++ b/conf.go
@@ -263,7 +263,7 @@ func (c *ConfigFile) MustValue(section, key string, defaultVal ...string) string
 	return val
 }
 
-// MustValue always returns value without error,
+// MustValueSet always returns value without error,
 // It returns empty string if error occurs, or the default value if given,
 // and a bool value indicates whether default value is returned.
 func (c *ConfigFile) MustValueSet(section, key string, defaultVal ...string) (string, bool) {


### PR DESCRIPTION
Hi, I've changed these public function comments to comply with [this standard](https://golang.org/doc/effective_go.html#commentary) in Effective Go. It's admittedly a small fix but I hope it helps!