### PR TITLE
GetSection deep copy map[string]string

### DIFF
--- a/conf.go
+++ b/conf.go
@@ -438,7 +438,7 @@ func (c *ConfigFile) GetSection(section string) (map[string]string, error) {
 	}
 
 	// Remove pre-defined key.
-	secMap := c.data[section]
+	secMap := deepCopy(c.data[section])
 	delete(c.data[section], " ")
 
 	// Section exists.

--- a/util.go
+++ b/util.go
@@ -1,0 +1,25 @@
+// Copyright 2013 Unknwon
+//
+// Licensed under the Apache License, Version 2.0 (the "License"): you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+package goconfig
+
+// deepCopy will copy a new map with different address
+func deepCopy(d map[string]string) map[string]string {
+	rs := make(map[string]string)
+	for k, v := range d {
+		rs[k] = v
+	}
+
+	return rs
+}


### PR DESCRIPTION
在GetSection函数中，有一个致命的缺陷，该缺陷将会引发fatal error: concurrent map read and map write导致服务panic


在GetSection() 中，secMap := c.data[section] 是浅复制，该操作导致外部和内部共用了一个内存地址，从而可能导致map同时读写

改为deepCopy可解决此问题

